### PR TITLE
Currently downloads.jabref.org shows the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-# Page redirection
-
-This page redirects to the current download provider of JabRef.
-
-The implementation follows a [tutorial by W3C](https://www.w3docs.com/snippets/html/how-to-redirect-a-web-page-in-html.html).


### PR DESCRIPTION
 and does not redirect

https://discourse.jabref.org/t/the-redirection-page-https-downloads-jabref-org-is-broken/1780